### PR TITLE
feat: support raw format for attach command

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -59,6 +59,7 @@ func init() {
 	flags.BoolVarP(&attachConfig.Force, "force", "f", false, "turning on this flag will force the attach, which will overwrite the layer if it already exists with same filepath")
 	flags.BoolVar(&attachConfig.Nydusify, "nydusify", false, "[EXPERIMENTAL] nydusify the model artifact")
 	flags.MarkHidden("nydusify")
+	flags.BoolVar(&attachConfig.Raw, "raw", false, "turning on this flag will attach model artifact layer in raw format")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))

--- a/internal/pb/pb.go
+++ b/internal/pb/pb.go
@@ -62,7 +62,7 @@ func NewProgressBar(writers ...io.Writer) *ProgressBar {
 		mpbv8.PopCompletedMode(),
 		mpbv8.WithAutoRefresh(),
 		mpbv8.WithWidth(60),
-		mpbv8.WithRefreshRate(200 * time.Millisecond),
+		mpbv8.WithRefreshRate(300 * time.Millisecond),
 	}
 
 	// If no writer specified, use stdout.

--- a/pkg/backend/attach_test.go
+++ b/pkg/backend/attach_test.go
@@ -73,7 +73,7 @@ func TestGetProcessor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.filepath, func(t *testing.T) {
-			proc := b.getProcessor(tt.filepath)
+			proc := b.getProcessor(tt.filepath, &config.Attach{})
 			if tt.wantType == "" {
 				assert.Nil(t, proc)
 			} else {

--- a/pkg/config/attach.go
+++ b/pkg/config/attach.go
@@ -26,6 +26,7 @@ type Attach struct {
 	Insecure     bool
 	Nydusify     bool
 	Force        bool
+	Raw          bool
 }
 
 func NewAttach() *Attach {
@@ -37,6 +38,7 @@ func NewAttach() *Attach {
 		Insecure:     false,
 		Nydusify:     false,
 		Force:        false,
+		Raw:          false,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to support attaching model artifact layers in raw format and includes several related updates across the codebase. Key changes include adding a `Raw` flag to the configuration, modifying the processor logic to handle the raw format, and updating tests and dependencies accordingly.

### New Feature: Support for Raw Format
* Added a `Raw` flag to the `Attach` struct in `pkg/config/attach.go` and initialized it in the `NewAttach` function. This flag enables attaching model artifact layers in raw format. [[1]](diffhunk://#diff-b92bfd83568948ba4f9f0ace8239fe300cc01387d2e8606cc58a3eaadc2ec522R29) [[2]](diffhunk://#diff-b92bfd83568948ba4f9f0ace8239fe300cc01387d2e8606cc58a3eaadc2ec522R41)
* Updated the `cmd/attach.go` file to include the `Raw` flag in the CLI options.

### Processor Logic Enhancements
* Modified the `getProcessor` function in `pkg/backend/attach.go` to use the `Raw` flag to determine the appropriate media type for different file types. Added support for raw formats in model config, model weight, model code, and model doc processors.
* Updated the `Attach` method to pass the `cfg` parameter to `getProcessor` and replaced manual slice manipulation with the `slices.Delete` function for improved readability and safety.

### Dependency and Test Updates
* Added the `slices` package to the imports in `pkg/backend/attach.go` to utilize the `slices.Delete` function.
* Updated the test case in `pkg/backend/attach_test.go` to pass the `cfg` parameter to the `getProcessor` function.

### Minor Adjustments
* Increased the refresh rate of the progress bar in `internal/pb/pb.go` from 200ms to 300ms for smoother updates.