### PR TITLE
feat: support inspect the config

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -49,6 +49,7 @@ func init() {
 	flags.BoolVar(&inspectConfig.Remote, "remote", false, "inspect model artifact from remote registry")
 	flags.BoolVar(&inspectConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
 	flags.BoolVar(&inspectConfig.Insecure, "insecure", false, "allow insecure connections")
+	flags.BoolVar(&inspectConfig.Config, "config", false, "inspect the config of the model artifact")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache inspect flags to viper: %w", err))

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -59,7 +59,7 @@ type Backend interface {
 	Prune(ctx context.Context, dryRun, removeUntagged bool) error
 
 	// Inspect inspects the model artifact.
-	Inspect(ctx context.Context, target string, cfg *config.Inspect) (*InspectedModelArtifact, error)
+	Inspect(ctx context.Context, target string, cfg *config.Inspect) (any, error)
 
 	// Extract extracts the model artifact.
 	Extract(ctx context.Context, target string, cfg *config.Extract) error

--- a/pkg/backend/inspect.go
+++ b/pkg/backend/inspect.go
@@ -66,7 +66,7 @@ type InspectedModelArtifactLayer struct {
 }
 
 // Inspect inspects the target from the storage.
-func (b *backend) Inspect(ctx context.Context, target string, cfg *config.Inspect) (*InspectedModelArtifact, error) {
+func (b *backend) Inspect(ctx context.Context, target string, cfg *config.Inspect) (any, error) {
 	logrus.Infof("inspect: starting inspect operation for target %s [config: %+v]", target, cfg)
 	_, err := ParseReference(target)
 	if err != nil {
@@ -91,6 +91,10 @@ func (b *backend) Inspect(ctx context.Context, target string, cfg *config.Inspec
 	}
 
 	logrus.Debugf("inspect: loaded model config for target %s [family: %s, name: %s]", target, config.Descriptor.Family, config.Descriptor.Name)
+
+	if cfg.Config {
+		return config, nil
+	}
 
 	inspectedModelArtifact := &InspectedModelArtifact{
 		ID:           manifest.Config.Digest.String(),

--- a/pkg/backend/inspect_test.go
+++ b/pkg/backend/inspect_test.go
@@ -131,7 +131,8 @@ func TestInspect(t *testing.T) {
 	mockStore.On("PullManifest", ctx, "example.com/repo", "tag").Return([]byte(manifest), "sha256:9ca701e8784e5656e2c36f10f82410a0af4c44f859590a28a3d1519ee1eea89d", nil)
 	mockStore.On("PullBlob", ctx, "example.com/repo", "sha256:e31b55920173ba79526491fbd01efe609c1d0d72c3a83df85b2c4fe74df2eea2").Return(io.NopCloser(bytes.NewReader([]byte(config))), nil)
 
-	inspected, err := b.Inspect(ctx, target, &pkgconfig.Inspect{})
+	inspectedAny, err := b.Inspect(ctx, target, &pkgconfig.Inspect{})
+	inspected := inspectedAny.(*InspectedModelArtifact)
 	assert.NoError(t, err)
 	assert.Equal(t, "sha256:e31b55920173ba79526491fbd01efe609c1d0d72c3a83df85b2c4fe74df2eea2", inspected.ID)
 	assert.Equal(t, "sha256:9ca701e8784e5656e2c36f10f82410a0af4c44f859590a28a3d1519ee1eea89d", inspected.Digest)

--- a/pkg/config/inspect.go
+++ b/pkg/config/inspect.go
@@ -20,6 +20,7 @@ type Inspect struct {
 	Remote    bool
 	PlainHTTP bool
 	Insecure  bool
+	Config    bool
 }
 
 func NewInspect() *Inspect {
@@ -27,5 +28,6 @@ func NewInspect() *Inspect {
 		Remote:    false,
 		PlainHTTP: false,
 		Insecure:  false,
+		Config:    false,
 	}
 }

--- a/test/mocks/backend/backend.go
+++ b/test/mocks/backend/backend.go
@@ -235,23 +235,23 @@ func (_c *Backend_Fetch_Call) RunAndReturn(run func(context.Context, string, *co
 }
 
 // Inspect provides a mock function with given fields: ctx, target, cfg
-func (_m *Backend) Inspect(ctx context.Context, target string, cfg *config.Inspect) (*backend.InspectedModelArtifact, error) {
+func (_m *Backend) Inspect(ctx context.Context, target string, cfg *config.Inspect) (interface{}, error) {
 	ret := _m.Called(ctx, target, cfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Inspect")
 	}
 
-	var r0 *backend.InspectedModelArtifact
+	var r0 interface{}
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Inspect) (*backend.InspectedModelArtifact, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Inspect) (interface{}, error)); ok {
 		return rf(ctx, target, cfg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Inspect) *backend.InspectedModelArtifact); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Inspect) interface{}); ok {
 		r0 = rf(ctx, target, cfg)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*backend.InspectedModelArtifact)
+			r0 = ret.Get(0).(interface{})
 		}
 	}
 
@@ -284,12 +284,12 @@ func (_c *Backend_Inspect_Call) Run(run func(ctx context.Context, target string,
 	return _c
 }
 
-func (_c *Backend_Inspect_Call) Return(_a0 *backend.InspectedModelArtifact, _a1 error) *Backend_Inspect_Call {
+func (_c *Backend_Inspect_Call) Return(_a0 interface{}, _a1 error) *Backend_Inspect_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Backend_Inspect_Call) RunAndReturn(run func(context.Context, string, *config.Inspect) (*backend.InspectedModelArtifact, error)) *Backend_Inspect_Call {
+func (_c *Backend_Inspect_Call) RunAndReturn(run func(context.Context, string, *config.Inspect) (interface{}, error)) *Backend_Inspect_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -751,6 +751,54 @@ func (_c *Backend_Tag_Call) Return(_a0 error) *Backend_Tag_Call {
 }
 
 func (_c *Backend_Tag_Call) RunAndReturn(run func(context.Context, string, string) error) *Backend_Tag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Upload provides a mock function with given fields: ctx, filepath, cfg
+func (_m *Backend) Upload(ctx context.Context, filepath string, cfg *config.Upload) error {
+	ret := _m.Called(ctx, filepath, cfg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Upload")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Upload) error); ok {
+		r0 = rf(ctx, filepath, cfg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Backend_Upload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Upload'
+type Backend_Upload_Call struct {
+	*mock.Call
+}
+
+// Upload is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filepath string
+//   - cfg *config.Upload
+func (_e *Backend_Expecter) Upload(ctx interface{}, filepath interface{}, cfg interface{}) *Backend_Upload_Call {
+	return &Backend_Upload_Call{Call: _e.mock.On("Upload", ctx, filepath, cfg)}
+}
+
+func (_c *Backend_Upload_Call) Run(run func(ctx context.Context, filepath string, cfg *config.Upload)) *Backend_Upload_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*config.Upload))
+	})
+	return _c
+}
+
+func (_c *Backend_Upload_Call) Return(_a0 error) *Backend_Upload_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Backend_Upload_Call) RunAndReturn(run func(context.Context, string, *config.Upload) error) *Backend_Upload_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This pull request introduces a new feature to inspect the configuration of a model artifact and updates the `Inspect` method to return a more flexible data type (`any`). Key changes include adding a new `--config` flag, modifying the `Inspect` method's return type, and implementing logic to handle the new flag.

### New Feature: Configuration Inspection

* [`cmd/inspect.go`](diffhunk://#diff-e1112a72d67ea1111e0c19d52bd341c23830344021f7f8534ffa74df2ad51d20R52): Added a new `--config` flag to allow users to inspect the configuration of a model artifact.
* [`pkg/config/inspect.go`](diffhunk://#diff-a0e57ac7281a88b8dd1ab4bf1b527e999d19980ca58b85c2091f37c06e4c6983R23-R31): Updated the `Inspect` struct to include a new `Config` field, with default initialization in the `NewInspect` function.

### Updates to `Inspect` Method

* [`pkg/backend/backend.go`](diffhunk://#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2L62-R62): Changed the return type of the `Inspect` method in the `Backend` interface from `*InspectedModelArtifact` to `any` for greater flexibility.
* [`pkg/backend/inspect.go`](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388L69-R69): Updated the `Inspect` method implementation to return the model configuration if the `Config` flag is set. [[1]](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388L69-R69) [[2]](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388R95-R98)