### PR TITLE
feat: add the MediaType of layer to inspected result

### DIFF
--- a/pkg/backend/inspect.go
+++ b/pkg/backend/inspect.go
@@ -57,6 +57,8 @@ type InspectedModelArtifact struct {
 
 // InspectedModelArtifactLayer is the data structure for model artifact layer that has been inspected.
 type InspectedModelArtifactLayer struct {
+	// MediaType is the media type of the model artifact layer.
+	MediaType string `json:"MediaType"`
 	// Digest is the digest of the model artifact layer.
 	Digest string `json:"Digest"`
 	// Size is the size of the model artifact layer.
@@ -114,9 +116,10 @@ func (b *backend) Inspect(ctx context.Context, target string, cfg *config.Inspec
 
 	for _, layer := range manifest.Layers {
 		inspectedModelArtifact.Layers = append(inspectedModelArtifact.Layers, InspectedModelArtifactLayer{
-			Digest:   layer.Digest.String(),
-			Size:     layer.Size,
-			Filepath: layer.Annotations[modelspec.AnnotationFilepath],
+			MediaType: layer.MediaType,
+			Digest:    layer.Digest.String(),
+			Size:      layer.Size,
+			Filepath:  layer.Annotations[modelspec.AnnotationFilepath],
 		})
 	}
 

--- a/pkg/backend/inspect_test.go
+++ b/pkg/backend/inspect_test.go
@@ -145,6 +145,7 @@ func TestInspect(t *testing.T) {
 	assert.Equal(t, "int8", inspected.Precision)
 	assert.Equal(t, "gptq", inspected.Quantization)
 	assert.Len(t, inspected.Layers, 8)
+	assert.Equal(t, "application/vnd.cnai.model.doc.v1.tar", inspected.Layers[0].MediaType)
 	assert.Equal(t, "sha256:5a96686deb327903f4310e9181ef2ee0bc7261e5181bd23ccdce6c575b6120a2", inspected.Layers[0].Digest)
 	assert.Equal(t, "LICENSE", inspected.Layers[0].Filepath)
 	assert.Equal(t, int64(13312), inspected.Layers[0].Size)


### PR DESCRIPTION
This pull request introduces a new `MediaType` field to the `InspectedModelArtifactLayer` struct in `pkg/backend/inspect.go`. The changes ensure that the media type of model artifact layers is captured during inspection and validated in tests.

### Enhancements to `InspectedModelArtifactLayer`:

* Added a `MediaType` field to the `InspectedModelArtifactLayer` struct to store the media type of model artifact layers. (`pkg/backend/inspect.go`, [pkg/backend/inspect.goR60-R61](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388R60-R61))
* Updated the `Inspect` function to populate the `MediaType` field for each layer during inspection. (`pkg/backend/inspect.go`, [pkg/backend/inspect.goR119](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388R119))

### Test updates:

* Enhanced the `TestInspect` function to validate the `MediaType` field for inspected layers, ensuring correctness. (`pkg/backend/inspect_test.go`, [pkg/backend/inspect_test.goR148](diffhunk://#diff-bf4b648860bc807309b451a8c58ec58ab1d838f95822247ce74fbfdd44573013R148))