### PR TITLE
feat: support using --authfile to login image repository

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -62,6 +62,7 @@ func init() {
 	flags.StringVarP(&loginConfig.Username, "username", "u", "", "Username for login")
 	flags.StringVarP(&loginConfig.Password, "password", "p", "", "Password for login")
 	flags.BoolVar(&loginConfig.PasswordStdin, "password-stdin", true, "Take the password from stdin by default")
+	flags.StringVar(&loginConfig.AuthFilePath, "authfile", "", "Path of the registry credentials file")
 	flags.BoolVar(&loginConfig.PlainHTTP, "plain-http", false, "Allow http connections to registry")
 	flags.BoolVar(&loginConfig.Insecure, "insecure", false, "Allow insecure connections to registry")
 
@@ -77,8 +78,12 @@ func runLogin(ctx context.Context, registry string) error {
 		return err
 	}
 
-	// read password from stdin if password-stdin is set
-	if loginConfig.PasswordStdin && loginConfig.Password == "" {
+	if loginConfig.AuthFilePath != "" {
+		loginConfig.Username, loginConfig.Password, err = config.ParseAuthFile(loginConfig.AuthFilePath, registry)
+		if err != nil {
+			return err
+		}
+	} else if loginConfig.PasswordStdin && loginConfig.Password == "" {
 		fmt.Print("Enter password: ")
 		password, err := terminal.ReadPassword(syscall.Stdin)
 		if err != nil {

--- a/pkg/config/login.go
+++ b/pkg/config/login.go
@@ -22,8 +22,21 @@ type Login struct {
 	Username      string
 	Password      string
 	PasswordStdin bool
+	AuthFilePath  string
 	PlainHTTP     bool
 	Insecure      bool
+}
+
+// AuthConfigEntry holds authentication credentials for a registry.
+type AuthConfigEntry struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}
+
+// AuthConfig is a structure for dockerconfigjson‑style files.
+type AuthConfig struct {
+	Auths map[string]AuthConfigEntry `json:"auths"`
 }
 
 func NewLogin() *Login {
@@ -31,12 +44,20 @@ func NewLogin() *Login {
 		Username:      "",
 		Password:      "",
 		PasswordStdin: true,
+		AuthFilePath:  "",
 		PlainHTTP:     false,
 		Insecure:      false,
 	}
 }
 
 func (l *Login) Validate() error {
+	if len(l.AuthFilePath) != 0 {
+		if len(l.Username) != 0 || len(l.Password) != 0 {
+			return fmt.Errorf("--authfile cannot be used with --username or --password")
+		}
+		return nil
+	}
+
 	if len(l.Username) == 0 {
 		return fmt.Errorf("missing username")
 	}

--- a/pkg/config/login_test.go
+++ b/pkg/config/login_test.go
@@ -31,6 +31,9 @@ func TestNewLogin(t *testing.T) {
 	if login.PasswordStdin != true {
 		t.Errorf("expected PasswordStdin to be true, got %v", login.PasswordStdin)
 	}
+	if login.AuthFilePath != "" {
+		t.Errorf("expected empty authFilePath, got %s", login.AuthFilePath)
+	}
 }
 
 func TestLogin_Validate(t *testing.T) {
@@ -63,6 +66,13 @@ func TestLogin_Validate(t *testing.T) {
 			login: &Login{
 				Username: "username",
 				Password: "password",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid login through --authfile",
+			login: &Login{
+				AuthFilePath: "dockerconfigjson",
 			},
 			wantErr: false,
 		},

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -1,0 +1,62 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ParseAuthFile(path, registry string) (string, string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("read authfile: %w", err)
+	}
+	var cfg AuthConfig
+	if err = json.Unmarshal(b, &cfg); err != nil {
+		return "", "", fmt.Errorf("decode json: %w", err)
+	}
+	return ExtractCred(cfg, registry)
+}
+
+func ExtractCred(cfg AuthConfig, registry string) (user, pass string, err error) {
+	entry, ok := cfg.Auths[registry]
+	if !ok {
+		return "", "", fmt.Errorf("registry %q not found in authfile", registry)
+	}
+
+	switch {
+	case entry.Username != "" && entry.Password != "":
+		return entry.Username, entry.Password, nil
+	case entry.Auth != "":
+		decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+		if err != nil {
+			return "", "", fmt.Errorf("base64 decode: %w", err)
+		}
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			return "", "", errors.New("malformed auth (expected username:password)")
+		}
+		return parts[0], parts[1], nil
+	default:
+		return "", "", errors.New("no username/password or auth field present for registry")
+	}
+}

--- a/pkg/config/utils_test.go
+++ b/pkg/config/utils_test.go
@@ -1,0 +1,115 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestExtractCred(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("user2:pass2"))
+
+	cases := []struct {
+		name     string
+		cfg      AuthConfig
+		registry string
+		wantUser string
+		wantPass string
+		wantErr  bool
+	}{
+		{
+			name:     "username password fields",
+			cfg:      AuthConfig{Auths: map[string]AuthConfigEntry{"example.io": {Username: "u", Password: "p"}}},
+			registry: "example.io",
+			wantUser: "u",
+			wantPass: "p",
+		},
+		{
+			name:     "auth base64 field",
+			cfg:      AuthConfig{Auths: map[string]AuthConfigEntry{"registry.local": {Auth: b64}}},
+			registry: "registry.local",
+			wantUser: "user2",
+			wantPass: "pass2",
+		},
+		{
+			name:     "registry missing",
+			cfg:      AuthConfig{Auths: map[string]AuthConfigEntry{}},
+			registry: "miss.io",
+			wantErr:  true,
+		},
+		{
+			name:     "malformed auth",
+			cfg:      AuthConfig{Auths: map[string]AuthConfigEntry{"bad": {Auth: base64.StdEncoding.EncodeToString([]byte("onlyuser"))}}},
+			registry: "bad",
+			wantErr:  true,
+		},
+		{
+			name:     "empty entry",
+			cfg:      AuthConfig{Auths: map[string]AuthConfigEntry{"empty": {}}},
+			registry: "empty",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, pass, err := ExtractCred(tc.cfg, tc.registry)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("expected err=%v got %v", tc.wantErr, err)
+			}
+			if !tc.wantErr {
+				if user != tc.wantUser || pass != tc.wantPass {
+					t.Fatalf("want (%s,%s) got (%s,%s)", tc.wantUser, tc.wantPass, user, pass)
+				}
+			}
+		})
+	}
+}
+
+// minimal I/O test to ensure ParseAuthFile ties together read+unmarshal+ExtractCred
+func TestParseAuthFile(t *testing.T) {
+	cfg := AuthConfig{Auths: map[string]AuthConfigEntry{"io": {Username: "a", Password: "b"}}}
+
+	tmp, err := os.CreateTemp(t.TempDir(), "authfile-*.json")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer tmp.Close()
+
+	enc := json.NewEncoder(tmp)
+	if err := enc.Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	path := tmp.Name()
+
+	user, pass, err := ParseAuthFile(path, "io")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if user != "a" || pass != "b" {
+		t.Fatalf("want (a,b) got (%s,%s)", user, pass)
+	}
+
+	// ensure file read error propagates
+	if _, _, err := ParseAuthFile("/non/exist", "io"); err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+}


### PR DESCRIPTION
This pull introduces a new feature to pass login authentication information through a file. The key changes include adding a new `--authfile` flag in the login command to avoid exposing usernames and passwords during the CI/CD process.
### CLI Improvements

- **cmd/login.go**: Add a `--authfile `flag to allow users to pass login authentication information through a file. Users can login through `modctl login --authfile=.dockerconfigjson.json example.io`.
- **pkg/config/login.go**: Update the Login struct to add a new AuthFilePath field with a default value of empty.
- **pkg/config/utils.go**: Added the parsing of username and password for dockerconfigjson format (https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets).

```
{
	"auths": {
		"my-registry.example:5000": {
			"username": "tiger",
			"password": "pass1234",
			"email": "tiger@acme.example",
			"auth": "dGlnZXI6cGFzczEyMzQ="
		}
	}
}
```