### PR TITLE
Add CNCF copyright footer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ It offers commands such as `build`, `pull`, `push`, and more, making it easy for
 
 You can find the full documentation on the [getting started](./docs/getting-started.md).
 
+## Copyright
+
+Copyright © contributors to ModelPack, established as ModelPack a Series of LF Projects, LLC.
+
 ## LICENSE
 
 Apache 2.0 License. Please see [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
## Description

Adds a copyright field with the text require by the Linux Foundation. Feel free to move this to another part of the README if needed.

## Related Issue

https://github.com/cncf/sandbox/issues/385

## Motivation and Context

This adds the copyright field mentioned on the CNCF onboarding checklist issue above and outlined in the Contribution Agreement instructions doc.
