### PR TITLE
Chore: Upgrade GolangCI-Lint To Support Go1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Golangci lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: v2.1
+          version: v2.4
           args: --verbose --timeout=10m


### PR DESCRIPTION
## Summary
This PR upgrades GolangCI-Lint to a newer version that includes support for Go 1.25.

### Notes
- No functional code changes.