### PR TITLE
chore: use PAT token for pull request in e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,9 +141,18 @@ jobs:
           sudo cp modctl/modctl /bin/modctl
           sudo chmod +x /bin/modctl
           modctl version
-          modctl login -u ${{ github.actor }} \
-                       -p ${{ secrets.GITHUB_TOKEN }} \
-                       ${{ env.REGISTRY }}
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Login using PAT for Pull Request"
+            modctl login -u ${{ github.actor }} \
+                         -p ${{ secrets.CR_PAT }} \
+                         ${{ env.REGISTRY }}
+          else
+            echo "Login using GITHUB_TOKEN"
+            modctl login -u ${{ github.actor }} \
+                         -p ${{ secrets.GITHUB_TOKEN }} \
+                         ${{ env.REGISTRY }}
+          fi
 
       - name: Test modctl E2E
         run: |


### PR DESCRIPTION
This pull request updates the authentication logic for the `modctl` login step in the end-to-end workflow. Now, the workflow uses a Personal Access Token (PAT) for authentication on pull request events, and falls back to the default `GITHUB_TOKEN` for other events.

Authentication logic improvements:

* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR144-R155): Added conditional logic to use the `CR_PAT` secret for `modctl` login during pull request events, and the `GITHUB_TOKEN` for all other events. This ensures appropriate credentials are used depending on the workflow trigger.