### PR TITLE
ci(e2e): remove PR event and unify registry login

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main, release-*]
     paths-ignore: ["**.md", "**.png", "**.jpg", "**.svg", "**/docs/**"]
-  pull_request:
-    branches: [main, release-*]
-    paths-ignore: ["**.md", "**.png", "**.jpg", "**.svg", "**/docs/**"]
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
@@ -141,18 +138,9 @@ jobs:
           sudo cp modctl/modctl /bin/modctl
           sudo chmod +x /bin/modctl
           modctl version
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Login using PAT for Pull Request"
-            modctl login -u ${{ github.actor }} \
-                         -p ${{ secrets.CR_PAT }} \
-                         ${{ env.REGISTRY }}
-          else
-            echo "Login using GITHUB_TOKEN"
-            modctl login -u ${{ github.actor }} \
-                         -p ${{ secrets.GITHUB_TOKEN }} \
-                         ${{ env.REGISTRY }}
-          fi
+          modctl login -u ${{ github.actor }} \
+                       -p ${{ secrets.GITHUB_TOKEN }} \
+                       ${{ env.REGISTRY }}
 
       - name: Test modctl E2E
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for end-to-end (E2E) tests. The main change is the removal of the workflow trigger for pull requests and the associated conditional authentication logic, simplifying the workflow to only run on pushes, scheduled events, and manual dispatches.

Workflow trigger changes:

* Removed the `pull_request` trigger from the `on:` section in `.github/workflows/e2e.yml`, so E2E tests will no longer run automatically on pull requests.

Authentication logic simplification:

* Removed conditional logic and Personal Access Token (PAT) authentication for pull requests in the E2E job steps; now, the workflow always uses the `GITHUB_TOKEN` for authentication.