### PR TITLE
fix(backend): remove redundant filepath check in extractLayer

### DIFF
--- a/pkg/backend/extract.go
+++ b/pkg/backend/extract.go
@@ -109,7 +109,7 @@ func exportModelArtifact(ctx context.Context, store storage.Storage, manifest oc
 // extractLayer extracts the layer to the output directory.
 func extractLayer(desc ocispec.Descriptor, outputDir string, reader io.Reader) error {
 	var filepath string
-	if desc.Annotations != nil && desc.Annotations[modelspec.AnnotationFilepath] != "" {
+	if desc.Annotations != nil {
 		if desc.Annotations[modelspec.AnnotationFilepath] != "" {
 			filepath = desc.Annotations[modelspec.AnnotationFilepath]
 		} else {


### PR DESCRIPTION
This pull request makes a minor change to the logic for extracting layers in the `extractLayer` function. The condition checking for the presence of annotations has been simplified for clarity.

* Simplified conditional logic in the `extractLayer` function by separating the check for annotation existence and the specific annotation value in `pkg/backend/extract.go`.