### PR TITLE
feat(build): publish multi-arch container image to GHCR on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,43 @@ jobs:
         name: modctl-${{ matrix.goos }}-${{ matrix.goarch }}
         path: dist/
 
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1    # v4.3.1
+
+    - name: Extract short commit
+      id: vars
+      run: echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c    # v4.2.0
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push image
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a    # v7.3.0
+      with:
+        context: .
+        file: ./build/Dockerfile
+        push: true
+        platforms: linux/amd64,linux/arm64
+        build-args: |
+          GITVERSION=${{ github.ref_name }}
+          GITCOMMIT=${{ steps.vars.outputs.commit }}
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          ghcr.io/${{ github.repository }}:latest
+
   create-release:
     needs: release
     runs-on: ubuntu-latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG GITVERSION=unknown
+ARG GITCOMMIT=unknown
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+      -ldflags "-w -X github.com/modelpack/modctl/pkg/version.GitVersion=${GITVERSION} \
+                   -X github.com/modelpack/modctl/pkg/version.GitCommit=${GITCOMMIT} \
+                   -X github.com/modelpack/modctl/pkg/version.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+      -o modctl \
+      main.go
+
+FROM gcr.io/distroless/static-debian13:nonroot
+COPY --from=builder /app/modctl /usr/local/bin/modctl
+ENTRYPOINT ["/usr/local/bin/modctl"]


### PR DESCRIPTION
Closes #630

Publishes `modctl` as a multi-arch container image so it can be used in CI/CD without installing the Go toolchain.

## Changes

- `build/Dockerfile` — cross-compiling builder (`golang:1.25` on `$BUILDPLATFORM`) plus a `gcr.io/distroless/static-debian13:nonroot` runtime, matching the layout used by [`model-csi-driver`](https://github.com/modelpack/model-csi-driver/blob/main/build/Dockerfile). The version ldflags mirror the ones in the existing release build, so `modctl version` reports the same fields from the image as from the released tarballs.
- `.github/workflows/release.yaml` — a `publish-image` job that pushes `ghcr.io/modelpack/modctl:<tag>` and `:latest` for `linux/amd64` and `linux/arm64` on every `v*` tag, using `GITHUB_TOKEN` with `packages: write`.

The job is independent of the existing binary matrix, and because the builder cross-compiles it needs no QEMU — the whole job takes about as long as a single `go build`.

## Why `CGO_ENABLED=0`

The released Linux tarball binaries are built with `CGO_ENABLED=1` and a statically linked glibc, which breaks NSS-backed `os/user` lookups. Dropping such a binary into a distroless base panics before any command runs:

```
$ docker run --rm modctl:repackaged version
panic: user: unknown userid 65532

goroutine 1 [running]:
github.com/modelpack/modctl/cmd.init.12()
	cmd/root.go:117 +0x444
```

`config.NewRoot()` calls `user.Current()` to derive the default storage and log directories, and panics if it fails. This is the same class of failure as #285 / #433 (`getgrgid_r` segfault in the static binaries).

Building with `CGO_ENABLED=0` avoids it entirely: `os/user` uses the pure-Go implementation that reads `/etc/passwd` (where distroless does have an entry for uid 65532), and the build selects the pure-Go go-git backend via the existing `//go:build !enable_libgit2` constraint in `pkg/source/git_gogit.go`.

Worth flagging for reviewers: this means the **image binary uses go-git while the tarball binaries use libgit2**. `model-csi-driver` already builds its release binaries with `CGO_ENABLED=0`, so there is precedent in the org, but if you would rather the image match the tarballs exactly, the alternative is to keep CGO and add the `osusergo`/`netgo` tags proposed in #433 — happy to switch.

## Testing

Built locally with `docker buildx` for both platforms:

```
$ docker buildx build --platform linux/amd64,linux/arm64 \
    --build-arg GITVERSION=v0.0.0-poc --build-arg GITCOMMIT=bd2c9f7 \
    -f build/Dockerfile -t modctl:multi .
```

The resulting manifest list carries `linux/amd64` and `linux/arm64` (42–46 MB per architecture). Both run as the non-root user:

```
$ docker run --rm modctl:arm64 version
Version:    v0.0.0-poc
Commit:     bd2c9f7
Platform:   linux
BuildTime:  2026-08-12T14:16:45Z
```

End-to-end check against Qwen2.5-0.5B-Instruct mounted into the container:

```
$ docker run --rm -v ./qwen2.5-0.5b-instruct:/model:ro modctl:arm64 \
    modelfile generate /model --name qwen2.5-0.5b-instruct \
    --format safetensors --param-size 0.5b -O /tmp
Generating modelfile for /model
Successfully generated modelfile:
NAME qwen2.5-0.5b-instruct
ARCH transformer
FAMILY qwen2
FORMAT safetensors
PARAMSIZE 0.5b
PRECISION bfloat16
CONFIG config.json
...
MODEL model.safetensors
DOC LICENSE
DOC README.md
```

## Notes

- The image has no shell, so `docker run ... modctl <args>` works but `sh -c` style invocations do not. If you would prefer a shell for CI systems that inject `commands:` blocks, `ubuntu:24.04` (as in `model-csi-driver`) is a drop-in change to the final stage.
