### PR TITLE
fix(build): tag images by version and major.minor instead of latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,6 +153,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302    # v6.2.0
+      with:
+        images: ghcr.io/${{ github.repository }}
+        flavor: latest=false
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+
     - name: Build and push image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a    # v7.3.0
       with:
@@ -163,9 +173,8 @@ jobs:
         build-args: |
           GITVERSION=${{ github.ref_name }}
           GITCOMMIT=${{ steps.vars.outputs.commit }}
-        tags: |
-          ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          ghcr.io/${{ github.repository }}:latest
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
 
   create-release:
     needs: release


### PR DESCRIPTION
Follow-up to #631, addressing @chlins's review comment about `:latest` being overwritten by every `v*` tag.

Rather than making `:latest` smarter, this drops it. Before 1.0 a floating `latest` is actively hazardous: every 0.x minor is allowed to break compatibility, so anything that pulls `modctl:latest` silently changes behaviour from one release to the next. What it is really useful for — "track this line without pinning every patch" — is served better by a moving `{{major}}.{{minor}}` tag, which in 0.x maps exactly onto the compatibility boundary.

## Changes

- Image tags now come from `docker/metadata-action` with two semver patterns: `{{version}}` for the immutable tag, and `{{major}}.{{minor}}` as the moving tag for a release line.
- `flavor: latest=false` keeps the action from adding `latest` on its own (its default is `latest=auto`).
- `labels: ${{ steps.meta.outputs.labels }}` comes along with the action, and `org.opencontainers.image.source` is what links the GHCR package back to this repository.

Nothing needs to consult the rest of the tag history: `{{major}}.{{minor}}` only ever moves within its own line, so a patch published on an older line updates that line alone and leaves newer ones untouched. Pre-releases never move a shared tag at all — the action only extends `{{version}}` for them.

## Resulting tags

| Pushed tag | Image tags |
| --- | --- |
| `v0.3.0` | `0.3.0`, `0.3` |
| `v0.2.3` (patch on an older line) | `0.2.3`, `0.2` |
| `v1.0.0-rc.1` (pre-release) | `1.0.0-rc.1` |
| `v0.2.1-cnai` (variant tag) | `0.2.1-cnai` |

## Behavioral change worth confirming

`{{version}}` strips the `v` prefix, so images become `ghcr.io/modelpack/modctl:0.3.0` where the merged workflow would have pushed `:v0.3.0`. No release has been cut since #631 merged, so nothing already published is affected either way. This is what `{{major}}.{{minor}}` produces anyway and what most images conventionally use.

## Testing

The four rows in the table above are actual output from `docker/metadata-action` v6.2.0 run against these inputs, and both pre-release forms this repository uses (`-rc.N` and the `-cnai` variant) correctly produce only their exact version.