### PR TITLE
fix(storage): propagate blob commit errors

### DIFF
--- a/pkg/storage/distribution/distribution.go
+++ b/pkg/storage/distribution/distribution.go
@@ -204,7 +204,7 @@ func (s *storage) PushBlob(ctx context.Context, repo string, blobReader io.Reade
 
 	desc, err := blob.Commit(ctx, provisional)
 	if err != nil {
-		return "", 0, nil
+		return "", 0, err
 	}
 
 	return desc.Digest.String(), desc.Size, nil

--- a/pkg/storage/distribution/distribution_test.go
+++ b/pkg/storage/distribution/distribution_test.go
@@ -1,0 +1,42 @@
+/*
+ *     Copyright 2026 The ModelPack Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package distribution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	distribution "github.com/distribution/distribution/v3"
+	godigest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushBlobPropagatesCommitError(t *testing.T) {
+	storage, err := NewStorage(t.TempDir())
+	require.NoError(t, err)
+
+	_, _, err = storage.PushBlob(context.Background(), "example.com/test", bytes.NewBufferString("blob"), ocispec.Descriptor{
+		Digest: godigest.FromString("different blob"),
+		Size:   4,
+	})
+
+	var invalidDigest distribution.ErrBlobInvalidDigest
+	require.True(t, errors.As(err, &invalidDigest))
+}


### PR DESCRIPTION
This pull request improves error handling in the `PushBlob` method and adds a corresponding unit test to ensure the correct propagation of errors. The main focus is to make sure that when `blob.Commit` fails, the error is properly returned to the caller instead of being silently ignored.

**Error handling improvements:**

* Updated `PushBlob` in `pkg/storage/distribution/distribution.go` to return the actual error from `blob.Commit` instead of returning `nil`, ensuring that commit errors are properly propagated.

**Testing enhancements:**

* Added a new test `TestPushBlobPropagatesCommitError` in `pkg/storage/distribution/distribution_test.go` to verify that `PushBlob` returns the correct error type when a commit fails due to an invalid digest.